### PR TITLE
Add CHANGELOG with 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+This project follows semantic versioning.
+
+Possible log types:
+
+- `[added]` for new features.
+- `[changed]` for changes in existing functionality.
+- `[deprecated]` for once-stable features removed in upcoming releases.
+- `[removed]` for deprecated features removed in this release.
+- `[fixed]` for any bug fixes.
+- `[security]` to invite users to upgrade in case of vulnerabilities.
+
+### Unreleased
+
+### v0.1.0 (2024-02-05)
+
+- [fixed] Handle unsupported / unknown schema versions (#2)
+
+### v0.0.6 (2021-07-10)
+
+No changelog available for this version.
+
+### v0.0.5 (2020-11-14)
+
+No changelog available for this version.
+
+### v0.0.4 (2020-11-13)
+
+No changelog available for this version.
+
+### v0.0.3 (2019-12-19)
+
+No changelog available for this version.
+
+### v0.0.2 (2019-10-31)
+
+No changelog available for this version.
+
+### v0.0.1 (2017-10-20)
+
+Initial release.


### PR DESCRIPTION
Should be merged after #3, and be immediately followed by a release tag.

@gidsi is this CHANGELOG / format OK for you? Do you have opinions on the version scheme? I'd go to 0.1.0 for this release. After that, minor increase for new features and patch increases for bugfixes.

Alternatively, we could also go straight to 1.0.0, since the project is a few years old now, and shouldn't drastically change anymore. (And if it does, we can always bump to 2.x)