### PR TITLE
Differentiate between "v14-style" versioning and "v12-style" versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Possible log types:
 
 ### Unreleased
 
+- [added] Support for schema 16-draft
+- [changed] Fail validation on usage of wrong versioning scheme (i.e. `.api` vs `.api_compatibility`)
+
 ### v0.2.0 (2024-12-29)
 
 - [added] Support for schema v15

--- a/versioning.go
+++ b/versioning.go
@@ -9,7 +9,7 @@ const (
 	V14
 )
 
-var SpaceApiVersioning = map[string]VersionSchema {
+var SpaceApiVersioning = map[string]VersionSchema{
 	"12": V12,
 	"13": V12,
 	"14": V14,

--- a/versioning.go
+++ b/versioning.go
@@ -1,0 +1,18 @@
+package spaceapivalidator
+
+type VersionSchema int
+
+const (
+	// versioning scheme introduced in v0.12: ".api" key
+	V12 VersionSchema = iota
+	// versioning scheme introduced in v14: ".api_compatibility" list
+	V14
+)
+
+var SpaceApiVersioning = map[string]VersionSchema {
+	"12": V12,
+	"13": V12,
+	"14": V14,
+	"15": V14,
+	"16": V14,
+}


### PR DESCRIPTION
At the moment, the validator merges all version indications from both `api` and `api_compatibility` into one, stripping of the leading `0.` from `api`. This leads to a few confusing situations where thinks like the following are considered valid or at least influence which schema versions an endpoint is (erroneously) validated against, possibly showing up twice in the "validated versions" list:

```json
{"api": "0.13", "api_compatibility": ["13", "14", "15"], ...}
```

```json
{"api": "0.15", "api_compatibility": ["15"], ...}
```

```json
{"api": "15", "api_compatibility": ["15"], ...}
```

This PR attempts to resolve this issue and make results a lot clearer by:
- Requiring versions 0.12 and 0.13 to be only indicated in the `api` field.
- Requiring versions 14 and later to be only indicated in the `api_compatibility` field.
- Failing validation if support for unknown schema versions is indicated, including wrong use of major vs minor schema version such as `13` or `0.14`.